### PR TITLE
Config update

### DIFF
--- a/docs/reference/0-config.md
+++ b/docs/reference/0-config.md
@@ -4,7 +4,7 @@
     options:
         members:
             - auth_exclude_paths
-            - auth_backend
+            - auth_backend_class
             - secret
             - hash_schemes
             - session_backend_config

--- a/docs/usage/0-configuration.md
+++ b/docs/usage/0-configuration.md
@@ -21,6 +21,7 @@ from advanced_alchemy.extensions.litestar.plugins import (
     SQLAlchemyInitPlugin,
 )
 from litestar.dto import DataclassDTO
+from litestar.security.session_auth import SessionAuth
 
 from litestar_users import LitestarUsers, LitestarUsersConfig
 from litestar_users.adapter.sqlalchemy.mixins import SQLAlchemyUserMixin
@@ -69,7 +70,7 @@ sqlalchemy_config = SQLAlchemyAsyncConfig(
 
 litestar_users = LitestarUsers(
     config=LitestarUsersConfig(
-        auth_backend="session",
+        auth_backend_class=SessionAuth,
         secret=ENCODING_SECRET,
         sqlalchemy_plugin_config=sqlalchemy_config,
         user_model=User,  # pyright: ignore

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -8,6 +8,7 @@ from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyAsyncConfig, 
 from litestar import Litestar
 from litestar.dto import DataclassDTO
 from litestar.exceptions import NotAuthorizedException
+from litestar.security.session_auth import SessionAuth
 from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -95,7 +96,7 @@ async def on_startup() -> None:
 
 litestar_users = LitestarUsers(
     config=LitestarUsersConfig(
-        auth_backend="session",
+        auth_backend_class=SessionAuth,
         secret=ENCODING_SECRET,
         sqlalchemy_plugin_config=sqlalchemy_config,
         user_model=User,  # pyright: ignore

--- a/examples/with_roles.py
+++ b/examples/with_roles.py
@@ -10,6 +10,7 @@ from advanced_alchemy.extensions.litestar.dto import SQLAlchemyDTO, SQLAlchemyDT
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from litestar import Litestar
 from litestar.dto import DataclassDTO
+from litestar.security.session_auth import SessionAuth
 from sqlalchemy import DateTime, ForeignKey, Integer, String, Uuid
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -114,7 +115,7 @@ async def on_startup() -> None:
 
 litestar_users = LitestarUsers(
     config=LitestarUsersConfig(
-        auth_backend="session",
+        auth_backend_class=SessionAuth,
         secret="sixteenbits",  # noqa: S106
         sqlalchemy_plugin_config=sqlalchemy_config,
         user_model=User,  # pyright: ignore

--- a/litestar_users/route_handlers.py
+++ b/litestar_users/route_handlers.py
@@ -11,6 +11,7 @@ from litestar import (
     get,
     patch,
     post,
+    put,
 )
 from litestar.contrib.jwt import JWTAuth, JWTCookieAuth
 from litestar.di import Provide
@@ -289,7 +290,7 @@ def get_user_management_handler(
 
     @get(
         IDENTIFIER_URI,
-        dto=user_update_dto,
+        dto=user_read_dto,
         return_dto=user_read_dto,
         guards=guards,
         opt=opt,
@@ -303,6 +304,7 @@ def get_user_management_handler(
 
     @patch(
         IDENTIFIER_URI,
+        dto=user_update_dto,
         return_dto=user_read_dto,
         guards=guards,
         opt=opt,
@@ -386,7 +388,7 @@ def get_role_management_handler(
     )
     async def update_role(id_: UUID, data: SQLARoleT, service: UserServiceType) -> SQLARoleT:
         """Update a role in the database."""
-
+        data.id = id_
         return cast(SQLARoleT, await service.update_role(id_, data))
 
     @delete(
@@ -403,7 +405,7 @@ def get_role_management_handler(
 
         return cast(SQLARoleT, await service.delete_role(id_))
 
-    @patch(
+    @put(
         return_dto=user_read_dto,
         path=assign_role_path,
         guards=guards,
@@ -416,7 +418,7 @@ def get_role_management_handler(
 
         return cast(SQLAUserT, await service.assign_role(data.user_id, data.role_id))
 
-    @patch(
+    @put(
         return_dto=user_read_dto,
         path=revoke_role_path,
         guards=guards,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,13 +14,14 @@ from advanced_alchemy.config import AsyncSessionConfig
 from advanced_alchemy.extensions.litestar.dto import SQLAlchemyDTO, SQLAlchemyDTOConfig
 from advanced_alchemy.extensions.litestar.plugins import SQLAlchemyAsyncConfig, SQLAlchemyInitPlugin
 from litestar import Litestar
-from litestar.contrib.jwt.jwt_token import Token
+from litestar.contrib.jwt import JWTAuth, JWTCookieAuth, Token
 from litestar.datastructures import State
 from litestar.dto import DataclassDTO
 from litestar.middleware.session.server_side import (
     ServerSideSessionConfig,
 )
 from litestar.repository.exceptions import RepositoryError
+from litestar.security.session_auth import SessionAuth
 from litestar.testing import TestClient
 from sqlalchemy.engine import URL
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
@@ -165,16 +166,16 @@ def sqlalchemy_plugin(sqlalchemy_plugin_config: SQLAlchemyAsyncConfig) -> SQLAlc
 
 @pytest.fixture(
     params=[
-        pytest.param("session", id="session"),
-        pytest.param("jwt", id="jwt"),
-        pytest.param("jwt_cookie", id="jwt_cookie"),
+        pytest.param(SessionAuth, id="session"),
+        pytest.param(JWTAuth, id="jwt"),
+        pytest.param(JWTCookieAuth, id="jwt_cookie"),
     ],
 )
 def litestar_users_config(
     request: pytest.FixtureRequest, sqlalchemy_plugin_config: SQLAlchemyAsyncConfig
 ) -> LitestarUsersConfig:
     return LitestarUsersConfig(  # pyright: ignore
-        auth_backend=request.param,
+        auth_backend_class=request.param,
         session_backend_config=ServerSideSessionConfig(),
         secret=ENCODING_SECRET,
         sqlalchemy_plugin_config=sqlalchemy_plugin_config,

--- a/tests/integration/test_authentication.py
+++ b/tests/integration/test_authentication.py
@@ -1,3 +1,4 @@
+from litestar.security.session_auth import SessionAuth
 from litestar.testing import TestClient
 
 from litestar_users import LitestarUsersConfig
@@ -15,7 +16,7 @@ def test_login(client: TestClient) -> None:
 def test_logout(client: TestClient, generic_user: User, litestar_users_config: LitestarUsersConfig) -> None:
     client.set_session_data({"user_id": str(generic_user.id)})
     response = client.post("/logout")
-    if litestar_users_config.auth_backend != "session":
+    if litestar_users_config.auth_backend_class != SessionAuth:
         assert response.status_code == 404
     else:
         assert response.status_code == 201

--- a/tests/integration/test_roles/test_roles.py
+++ b/tests/integration/test_roles/test_roles.py
@@ -1,0 +1,46 @@
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+
+import pytest
+
+if TYPE_CHECKING:
+    from litestar.testing import TestClient
+
+    from .conftest import Role, User
+
+
+@pytest.mark.usefixtures("authenticate_admin")
+class TestRoleManagement:
+    def test_create_role(self, client: "TestClient") -> None:
+        response = client.post("/users/roles", json={"name": "editor", "description": "..."})
+        assert response.status_code == 201
+        assert response.json() == {
+            "id": ANY,
+            "name": "editor",
+            "description": "...",
+        }
+
+    def test_update_role(self, client: "TestClient", writer_role: "Role") -> None:
+        response = client.patch("/users/roles/76ddde3c-91d0-4b58-baa4-bfc4b3892ab2", json={"name": "editor"})
+        assert response.status_code == 200
+        assert response.json() == {
+            "id": str(writer_role.id),
+            "name": "editor",
+            "description": writer_role.description,
+        }
+
+    def test_delete_role(self, client: "TestClient") -> None:
+        response = client.delete("/users/roles/76ddde3c-91d0-4b58-baa4-bfc4b3892ab2")
+        assert response.status_code == 200
+
+    def test_assign_role(self, client: "TestClient", generic_user: "User", writer_role: "Role") -> None:
+        response = client.put(
+            "/users/roles/assign", json={"user_id": str(generic_user.id), "role_id": str(writer_role.id)}
+        )
+        assert response.status_code == 200
+
+    def test_revoke_role(self, client: "TestClient", admin_user: "User", admin_role: "Role") -> None:
+        response = client.put(
+            "/users/roles/revoke", json={"user_id": str(admin_user.id), "role_id": str(admin_role.id)}
+        )
+        assert response.status_code == 200

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
-from litestar.contrib.jwt import Token
+from litestar.contrib.jwt import JWTAuth, JWTCookieAuth, Token
 from litestar.exceptions import NotAuthorizedException
+from litestar.security.session_auth import SessionAuth
 
 from .constants import ENCODING_SECRET
 
@@ -35,9 +36,9 @@ class MockAuth:
 
         Works with both session and JWT backends.
         """
-        if self.config.auth_backend == "session":
+        if self.config.auth_backend_class == SessionAuth:
             self.client.set_session_data({"user_id": user_id})
-        elif self.config.auth_backend == "jwt" or self.config.auth_backend == "jwt_cookie":
+        elif self.config.auth_backend_class == JWTAuth or self.config.auth_backend_class == JWTCookieAuth:
             token = create_jwt(str(user_id))
             self.client.headers["Authorization"] = "Bearer " + token
 


### PR DESCRIPTION
This PR aims to:

- Change the `LitestarUsersConfig` attribute `auth_backend` to `auth_backend_class`, so as to no longer accept string arguments.
- Add missing role management tests
- Change role assignment/revocation route handlers from HTTP `PATCH` to `PUT`