### PR TITLE
Update user_handlers to accept user id from BigInteger type

### DIFF
--- a/litestar_users/user_handlers.py
+++ b/litestar_users/user_handlers.py
@@ -78,7 +78,12 @@ async def jwt_retrieve_user_handler(token: Token, connection: ASGIConnection) ->
     try:
         # undocumented relationship loading api
         statement = _check_update_statement(connection, repository.statement)
-        user = await repository.get(UUID(token.sub), statement=statement)
+        user_id: UUID | int | None = None
+        try:
+            user_id = UUID(token.sub)
+        except ValueError:
+            user_id = int(token.sub)
+        user = await repository.get(user_id, statement=statement)
         if user.is_active and user.is_verified:
             return user  # type: ignore[no-any-return]
     except NotFoundError:


### PR DESCRIPTION
As of right now we receive the following error if the user model uses integer as a primary key

![image](https://github.com/LonelyVikingMichael/litestar-users/assets/2985027/4960712f-594a-44e2-9f12-9b8055a90575)
