### PR TITLE
feat: config attribute to enable/disable the verification process

### DIFF
--- a/docs/reference/0-config.md
+++ b/docs/reference/0-config.md
@@ -17,6 +17,7 @@
             - role_read_dto
             - role_update_dto
             - user_service_class
+            - require_verification_on_registration
             - auth_handler_config
             - current_user_handler_config
             - password_reset_handler_config

--- a/docs/usage/3-the-user-service.md
+++ b/docs/usage/3-the-user-service.md
@@ -7,6 +7,9 @@ The [`UserService`][litestar_users.service.BaseUserService] class is the interfa
 * [`send_verification_token`][litestar_users.service.BaseUserService.send_verification_token]
 * [`send_password_reset_token`][litestar_users.service.BaseUserService.send_password_reset_token]
 
+!!!note
+    The method [`send_verification_token`][litestar_users.service.BaseUserService.send_verification_token] is used only when [`require_verification_on_registration`][litestar_users.config.LitestarUsersConfig.require_verification_on_registration] is set to `True` (the default value). If no verification is required and [`require_verification_on_registration`][litestar_users.config.LitestarUsersConfig.require_verification_on_registration] is set to `False`, the method will not be invoked.
+
 ### Example
 
 ```python

--- a/docs/usage/4-route-handler-configs.md
+++ b/docs/usage/4-route-handler-configs.md
@@ -28,7 +28,7 @@ Provides the following route handlers:
 
 Provides the following route handlers:
 
-* `register` (aka signup). By default, newly registered users will need to verify their account before they can proceed to login.
+* `register` (aka signup). By default, newly registered users will need to verify their account before they can proceed to login. This behavior can be changed setting [`require_verification_on_registration`][litestar_users.config.LitestarUsersConfig.require_verification_on_registration] to `False` to disable verification for new users.
 
 ## [`RoleManagementHandlerConfig`][litestar_users.config.RoleManagementHandlerConfig]
 

--- a/litestar_users/config.py
+++ b/litestar_users/config.py
@@ -223,6 +223,8 @@ class LitestarUsersConfig(Generic[UserT, RoleT]):
     Notes:
         - The attribute must be present on the `User` database model and must have a unique value.
     """
+    require_verification_on_registration: bool = True
+    """Whether the registration of a new user requires verification. Defaults to `True`."""
     auth_handler_config: AuthHandlerConfig | None = None
     """Optional instance of [AuthHandlerConfig][litestar_users.config.AuthHandlerConfig]. If set, registers the route
     handler(s) on the app.

--- a/litestar_users/dependencies.py
+++ b/litestar_users/dependencies.py
@@ -47,4 +47,5 @@ def provide_user_service(state: State, request: Request) -> BaseUserService:
         role_repository=role_repository,
         secret=litestar_users_config.secret,
         hash_schemes=litestar_users_config.hash_schemes,
+        require_verification_on_registration=litestar_users_config.require_verification_on_registration,
     )

--- a/litestar_users/service.py
+++ b/litestar_users/service.py
@@ -36,6 +36,7 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
         user_repository: SQLAlchemyUserRepository[SQLAUserT],
         hash_schemes: Sequence[str] | None = None,
         role_repository: SQLAlchemyRoleRepository[SQLARoleT, SQLAUserT] | None = None,
+        require_verification_on_registration: bool = True,
     ) -> None:
         """User service constructor.
 
@@ -45,6 +46,7 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
             user_repository: A `UserRepository` instance.
             hash_schemes: Schemes to use for password encryption.
             role_repository: A `RoleRepository` instance.
+            require_verification_on_registration: Whether the registration of a new user requires verification.
         """
         self.user_repository = user_repository
         self.role_repository = role_repository
@@ -54,6 +56,7 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
         if role_repository is not None:
             self.role_model = role_repository.model_type
         self.user_auth_identifier = user_auth_identifier
+        self.require_verification_on_registration = require_verification_on_registration
 
     async def add_user(self, user: SQLAUserT, verify: bool = False, activate: bool = True) -> SQLAUserT:
         """Create a new user programmatically.

--- a/litestar_users/service.py
+++ b/litestar_users/service.py
@@ -85,8 +85,12 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
         await self.pre_registration_hook(data, request)
 
         data["password_hash"] = self.password_manager.hash(data.pop("password"))
-        user = await self.add_user(self.user_model(**data))  # type: ignore[arg-type]
-        await self.initiate_verification(user)  # TODO: make verification optional?
+
+        verify = not self.require_verification_on_registration
+        user = await self.add_user(self.user_model(**data), verify=verify)  # type: ignore[arg-type]
+
+        if self.require_verification_on_registration:
+            await self.initiate_verification(user)
 
         await self.post_registration_hook(user, request)
 

--- a/litestar_users/service.py
+++ b/litestar_users/service.py
@@ -188,6 +188,9 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
 
         Args:
             user: The user requesting verification.
+
+        Notes:
+            - The user verification flow is not initiated when `require_verification_on_registration` is set to `False`.
         """
         token = self.generate_token(user.id, aud="verify")
         await self.send_verification_token(user, token)
@@ -201,6 +204,7 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
 
         Notes:
         - Develepors need to override this method to facilitate sending the token via email, sms etc.
+        - This method is not invoked when `require_verification_on_registration` is set to `False`.
         """
 
     async def verify(self, encoded_token: str, request: Request | None = None) -> SQLAUserT:
@@ -336,8 +340,6 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
         Notes:
         - Uncaught exceptions in this method could result in returning a HTTP 500 status
         code while successfully creating the user in the database.
-        - It's possible to skip verification entirely by setting `user.is_verified`
-        to `True` here.
         """
         return
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -194,6 +194,7 @@ def litestar_users_config(request: pytest.FixtureRequest) -> LitestarUsersConfig
         user_read_dto=UserReadDTO,
         user_update_dto=UserUpdateDTO,
         user_service_class=UserService,
+        require_verification_on_registration=True,
         auth_handler_config=AuthHandlerConfig(),
         current_user_handler_config=CurrentUserHandlerConfig(),
         password_reset_handler_config=PasswordResetHandlerConfig(),


### PR DESCRIPTION
This PR adds a new config attribute to enable/disable the verification process.

Currently, verification of new users can be skipped by setting `user.is_verified` to `True` in the `post_registration_hook` method, but I feel that this approach is a bit cumbersome. To streamline the process of enabling/disabling user verification, I've added a new configuration attribute (`require_verification_on_registration`) to the `LitestarUsersConfig` class. This boolean attribute, which defaults to `True`, can be set to `False` to explicitly disable verification.

The main changes are in the `register` method of the `BaseUserService` class, where it is checked whether verification is required before initiating the verification flow. If verification is not required, the new user is created with `is_verified` set to `True`. I've also added a new test to check that the verification process can be correctly disabled, and I've updated the docs accordingly.