### PR TITLE
Expose repository `auto_commit` option

### DIFF
--- a/docs/reference/0-config.md
+++ b/docs/reference/0-config.md
@@ -5,6 +5,7 @@
         members:
             - auth_exclude_paths
             - auth_backend_class
+            - auto_commit_transactions
             - secret
             - hash_schemes
             - session_backend_config

--- a/docs/usage/0-configuration.md
+++ b/docs/usage/0-configuration.md
@@ -77,6 +77,7 @@ litestar_users = LitestarUsersPlugin(
         user_registration_dto=UserRegistrationDTO,
         user_update_dto=UserUpdateDTO,
         user_service_class=UserService,  # pyright: ignore
+        auto_commit_transactions=False,
         auth_handler_config=AuthHandlerConfig(),
         register_handler_config=RegisterHandlerConfig(),
         verification_handler_config=VerificationHandlerConfig(),

--- a/litestar_users/adapter/sqlalchemy/repository.py
+++ b/litestar_users/adapter/sqlalchemy/repository.py
@@ -16,15 +16,16 @@ __all__ = ["SQLAlchemyRoleRepository", "SQLAlchemyUserRepository"]
 class SQLAlchemyUserRepository(SQLAlchemyAsyncRepository[SQLAUserT], Generic[SQLAUserT]):
     """SQLAlchemy implementation of user persistence layer."""
 
-    def __init__(self, session: AsyncSession, model_type: type[SQLAUserT]) -> None:
+    def __init__(self, session: AsyncSession, model_type: type[SQLAUserT], **kwargs: Any) -> None:
         """Repository for users.
 
         Args:
             session: Session managing the unit-of-work for the operation.
             model_type: A subclass of `SQLAlchemyUserModel`.
+            kwargs: Additional keyword arguments to pass to superclass.
         """
         self.model_type = model_type
-        super().__init__(session=session)
+        super().__init__(session=session, **kwargs)
 
     async def _update(self, user: SQLAUserT, data: dict[str, Any]) -> SQLAUserT:
         for key, value in data.items():

--- a/litestar_users/config.py
+++ b/litestar_users/config.py
@@ -181,6 +181,8 @@ class LitestarUsersConfig(Generic[UserT, RoleT]):
     """
     auth_exclude_paths: list[str] = field(default_factory=lambda: ["/schema"])
     """Paths to be excluded from authentication checks."""
+    auto_commit_transactions: bool = False
+    """Whether to auto_commit transactions. Defaults to `False`."""
     hash_schemes: list[str] = field(default_factory=lambda: ["argon2"])
     """Schemes to use for password encryption.
 

--- a/litestar_users/dependencies.py
+++ b/litestar_users/dependencies.py
@@ -33,7 +33,9 @@ def provide_user_service(state: State, request: Request) -> BaseUserService:
 
     litestar_users_config = get_litestar_users_plugin(request.app)._config
     user_repository = litestar_users_config.user_repository_class(
-        session=session, model_type=litestar_users_config.user_model
+        session=session,
+        model_type=litestar_users_config.user_model,
+        auto_commit=litestar_users_config.auto_commit_transactions,
     )
     role_repository: SQLAlchemyRoleRepository | None = (
         None

--- a/litestar_users/user_handlers.py
+++ b/litestar_users/user_handlers.py
@@ -31,7 +31,9 @@ def _get_user_repository(connection: ASGIConnection) -> SQLAlchemyUserRepository
 
     litestar_users_config = get_litestar_users_plugin(connection.app)._config
     return litestar_users_config.user_repository_class(
-        session=async_session, model_type=litestar_users_config.user_model
+        session=async_session,
+        model_type=litestar_users_config.user_model,
+        auto_commit=litestar_users_config.auto_commit_transactions,
     )
 
 


### PR DESCRIPTION
Enable developers to set `auto_commit_transactions` on the config object, which propagates to the user repository.

This allows committing on a per-repository-call basis, as opposed to atomic commits before sending out a Litestar response.