### PR TITLE
feat: expose load optons to the authentication lookup

### DIFF
--- a/litestar_users/route_handlers.py
+++ b/litestar_users/route_handlers.py
@@ -113,6 +113,7 @@ def get_auth_handler(
     user_read_dto: type[SQLAlchemyDTO],  # pyright: ignore
     auth_backend: JWTAuth | JWTCookieAuth | SessionAuth,
     authentication_schema: Any,
+    opt: dict[str, Any] | None = None,
     tags: list[str] | None = None,
 ) -> Router:
     """Get authentication/login route handlers.
@@ -123,6 +124,7 @@ def get_auth_handler(
         user_read_dto: A subclass of [UserReadDTO][litestar_users.schema.UserReadDTO]
         auth_backend: A Litestar authentication backend.
         authentication_schema: The object that defines the request body schema.
+        opt: Optional route handler 'opts' to provide additional context to Guards.
         tags: A list of string tags to append to the schema of the route handlers.
     """
 
@@ -132,6 +134,7 @@ def get_auth_handler(
         dependencies={"service": Provide(provide_user_service, sync_to_thread=False)},
         exclude_from_auth=True,
         tags=tags,
+        opt=opt,
     )
     async def login_session(
         data: authentication_schema,  # pyright: ignore
@@ -156,6 +159,7 @@ def get_auth_handler(
         dependencies={"service": Provide(provide_user_service, sync_to_thread=False)},
         exclude_from_auth=True,
         tags=tags,
+        opt=opt,
     )
     async def login_jwt(
         data: authentication_schema,  # pyright: ignore
@@ -194,7 +198,7 @@ def get_current_user_handler(
     path: str,
     user_read_dto: type[SQLAlchemyDTO],  # pyright: ignore
     user_update_dto: type[SQLAlchemyDTO],  # pyright: ignore
-    opt: dict[str, Any],
+    opt: dict[str, Any] | None = None,
     tags: list[str] | None = None,
 ) -> Router:
     """Get current-user route handlers.
@@ -269,9 +273,9 @@ def get_user_management_handler(
     path_prefix: str,
     guards: list["Guard"],
     identifier_uri: str,
-    opt: dict[str, Any],
     user_read_dto: type[SQLAlchemyDTO],  # pyright: ignore
     user_update_dto: type[SQLAlchemyDTO],  # pyright: ignore
+    opt: dict[str, Any] | None = None,
     tags: list[str] | None = None,
 ) -> Router:
     """Get user management route handlers.
@@ -340,11 +344,11 @@ def get_role_management_handler(
     revoke_role_path: str,
     guards: list["Guard"],
     identifier_uri: str,
-    opt: dict[str, Any],
     role_create_dto: type[SQLAlchemyDTO],  # pyright: ignore
     role_read_dto: type[SQLAlchemyDTO],  # pyright: ignore
     role_update_dto: type[SQLAlchemyDTO],  # pyright: ignore
     user_read_dto: type[SQLAlchemyDTO],  # pyright: ignore
+    opt: dict[str, Any] | None = None,
     tags: list[str] | None = None,
 ) -> Router:
     """Get role management route handlers.

--- a/litestar_users/service.py
+++ b/litestar_users/service.py
@@ -158,6 +158,9 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
             data: User authentication data transfer object.
             request: The litestar request that initiated the action.
         """
+
+        load: LoadSpec | None = request.route_handler.opt.get("user_load_options") if request else None
+
         # avoid early returns to mitigate timing attacks.
         # check if user supplied logic should allow authentication, but only
         # supply the result later.
@@ -166,7 +169,8 @@ class BaseUserService(Generic[SQLAUserT, SQLARoleT]):  # pylint: disable=R0904
         try:
             user = await self.user_repository.get_one(
                 func.lower(getattr(self.user_model, self.user_auth_identifier))
-                == getattr(data, self.user_auth_identifier).lower()
+                == getattr(data, self.user_auth_identifier).lower(),
+                load=load,
             )
         except NotFoundError:
             # trigger passlib's `dummy_verify` method


### PR DESCRIPTION
This change allows users to set load options for user retrieval on authentication, i.e. load `user.roles` or any other relationship.